### PR TITLE
Move to @nextcloud/vue-dashboard

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2240,6 +2240,27 @@
         }
       }
     },
+    "@babel/polyfill": {
+      "version": "7.2.5",
+      "resolved": "https://registry.npmjs.org/@babel/polyfill/-/polyfill-7.2.5.tgz",
+      "integrity": "sha512-8Y/t3MWThtMLYr0YNC/Q76tqN1w30+b0uQMeFUYauG2UGTR19zyUtFrAzT23zNtBxPp+LbE5E/nwV/q/r3y6ug==",
+      "requires": {
+        "core-js": "^2.5.7",
+        "regenerator-runtime": "^0.12.0"
+      },
+      "dependencies": {
+        "core-js": {
+          "version": "2.6.11",
+          "resolved": "https://registry.npmjs.org/core-js/-/core-js-2.6.11.tgz",
+          "integrity": "sha512-5wjnpaT/3dV+XB4borEsnAYQchn00XSgTAWKDkEqv+K8KevjbzmofK6hfJ9TZIlpj2N0xQpazy7PiRQiWHqzWg=="
+        },
+        "regenerator-runtime": {
+          "version": "0.12.1",
+          "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.12.1.tgz",
+          "integrity": "sha512-odxIc1/vDlo4iZcfXqRYFj0vpXFNoGdKMAUieAlFYO6m/nl5e9KR/beGf41z4a1FI+aQgtjhuaSlDxQ0hmkrHg=="
+        }
+      }
+    },
     "@babel/preset-env": {
       "version": "7.10.4",
       "resolved": "https://registry.npmjs.org/@babel/preset-env/-/preset-env-7.10.4.tgz",
@@ -3512,6 +3533,44 @@
         "vue-multiselect": "^2.1.6",
         "vue-visible": "^1.0.2",
         "vue2-datepicker": "^3.4.1"
+      }
+    },
+    "@nextcloud/vue-dashboard": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/@nextcloud/vue-dashboard/-/vue-dashboard-0.1.0.tgz",
+      "integrity": "sha512-ESaeGVcD9IOxo4c23nYdT6vm1dMBG/bY9um3eZh+SouRizipW9mfEE+AhGaP7QiQko/XpztJ53jVUZx7FP3ORA==",
+      "requires": {
+        "@nextcloud/vue": "^2.3.0",
+        "core-js": "^3.6.4",
+        "vue": "^2.6.11"
+      },
+      "dependencies": {
+        "@nextcloud/vue": {
+          "version": "2.3.0",
+          "resolved": "https://registry.npmjs.org/@nextcloud/vue/-/vue-2.3.0.tgz",
+          "integrity": "sha512-6uf7Hu4Obaet7BOs9H/Ng63xAYqks9CL7hsOOHGUzWFYrPPBxgt79iD9OOPpPfJuLQ3Nnuibh942X1QreCBRkw==",
+          "requires": {
+            "@nextcloud/auth": "^1.2.3",
+            "@nextcloud/axios": "^1.3.2",
+            "@nextcloud/dialogs": "^1.3.0",
+            "@nextcloud/event-bus": "^1.1.4",
+            "@nextcloud/l10n": "^1.2.3",
+            "@nextcloud/router": "^1.0.2",
+            "core-js": "^3.6.5",
+            "debounce": "1.2.0",
+            "emoji-mart-vue-fast": "^7.0.2",
+            "hammerjs": "^2.0.8",
+            "md5": "^2.2.1",
+            "regenerator-runtime": "^0.13.5",
+            "v-click-outside": "^3.0.1",
+            "v-tooltip": "^2.0.3",
+            "vue": "^2.6.11",
+            "vue-color": "^2.7.1",
+            "vue-multiselect": "^2.1.6",
+            "vue-visible": "^1.0.2",
+            "vue2-datepicker": "^3.4.1"
+          }
+        }
       }
     },
     "@types/anymatch": {
@@ -5115,6 +5174,31 @@
           "resolved": "https://registry.npmjs.org/bn.js/-/bn.js-4.11.9.tgz",
           "integrity": "sha512-E6QoYqCKZfgatHTdHzs1RRKP7ip4vvm+EyRUeE2RF0NblwVvb0p6jSVeNTOFxPn26QXN2o6SMfNxKp6kU8zQaw==",
           "dev": true
+        }
+      }
+    },
+    "emoji-mart-vue-fast": {
+      "version": "7.0.3",
+      "resolved": "https://registry.npmjs.org/emoji-mart-vue-fast/-/emoji-mart-vue-fast-7.0.3.tgz",
+      "integrity": "sha512-9BdX1QvWCOKEnmd20wcej7GaB/2/cesgodGJCCQirz1NtW3xctg1pWEYJHbAcjRHSHDzLDC+Y2xj9a2tO8T5hQ==",
+      "requires": {
+        "@babel/polyfill": "7.2.5",
+        "@babel/runtime": "7.3.4",
+        "vue-virtual-scroller": "^1.0.0-rc.2"
+      },
+      "dependencies": {
+        "@babel/runtime": {
+          "version": "7.3.4",
+          "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.3.4.tgz",
+          "integrity": "sha512-IvfvnMdSaLBateu0jfsYIpZTxAc2cKEXEMiezGGN75QcBcecDUKd3PgLAncT0oOgxKy8dd8hrJKj9MfzgfZd6g==",
+          "requires": {
+            "regenerator-runtime": "^0.12.0"
+          }
+        },
+        "regenerator-runtime": {
+          "version": "0.12.1",
+          "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.12.1.tgz",
+          "integrity": "sha512-odxIc1/vDlo4iZcfXqRYFj0vpXFNoGdKMAUieAlFYO6m/nl5e9KR/beGf41z4a1FI+aQgtjhuaSlDxQ0hmkrHg=="
         }
       }
     },
@@ -8352,6 +8436,11 @@
         }
       }
     },
+    "scrollparent": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/scrollparent/-/scrollparent-2.0.1.tgz",
+      "integrity": "sha1-cV1bnMV3YPsivczDvvtb/gaxoxc="
+    },
     "scss-tokenizer": {
       "version": "0.2.3",
       "resolved": "https://registry.npmjs.org/scss-tokenizer/-/scss-tokenizer-0.2.3.tgz",
@@ -9243,6 +9332,11 @@
       "resolved": "https://registry.npmjs.org/vue-multiselect/-/vue-multiselect-2.1.6.tgz",
       "integrity": "sha512-s7jmZPlm9FeueJg1RwJtnE9KNPtME/7C8uRWSfp9/yEN4M8XcS/d+bddoyVwVnvFyRh9msFo0HWeW0vTL8Qv+w=="
     },
+    "vue-observe-visibility": {
+      "version": "0.4.6",
+      "resolved": "https://registry.npmjs.org/vue-observe-visibility/-/vue-observe-visibility-0.4.6.tgz",
+      "integrity": "sha512-xo0CEVdkjSjhJoDdLSvoZoQrw/H2BlzB5jrCBKGZNXN2zdZgMuZ9BKrxXDjNP2AxlcCoKc8OahI3F3r3JGLv2Q=="
+    },
     "vue-resize": {
       "version": "0.4.5",
       "resolved": "https://registry.npmjs.org/vue-resize/-/vue-resize-0.4.5.tgz",
@@ -9295,6 +9389,16 @@
           "resolved": "https://registry.npmjs.org/isobject/-/isobject-4.0.0.tgz",
           "integrity": "sha512-S/2fF5wH8SJA/kmwr6HYhK/RI/OkhD84k8ntalo0iJjZikgq1XFvR5M8NPT1x5F7fBwCG3qHfnzeP/Vh/ZxCUA=="
         }
+      }
+    },
+    "vue-virtual-scroller": {
+      "version": "1.0.10",
+      "resolved": "https://registry.npmjs.org/vue-virtual-scroller/-/vue-virtual-scroller-1.0.10.tgz",
+      "integrity": "sha512-Hn4qSBDhRY4XdngPioYy/ykDjrLX/NMm1fQXm/4UQQ/Xv1x8JbHGFZNftQowTcfICgN7yc31AKnUk1UGLJ2ndA==",
+      "requires": {
+        "scrollparent": "^2.0.1",
+        "vue-observe-visibility": "^0.4.4",
+        "vue-resize": "^0.4.5"
       }
     },
     "vue-visible": {

--- a/package.json
+++ b/package.json
@@ -28,6 +28,7 @@
     "extends @nextcloud/browserslist-config"
   ],
   "dependencies": {
+    "@nextcloud/vue-dashboard": "^0.1.0",
     "@nextcloud/router": "^1.1.0",
     "@nextcloud/auth": "^1.3.0",
     "@nextcloud/vue": "^2.2.1",

--- a/src/views/Dashboard.vue
+++ b/src/views/Dashboard.vue
@@ -44,7 +44,7 @@ import { generateUrl } from '@nextcloud/router'
 import { showSuccess, showError } from '@nextcloud/dialogs'
 import { getLocale } from '@nextcloud/l10n'
 import moment from '@nextcloud/moment'
-import DashboardWidget from '../components/DashboardWidget'
+import { DashboardWidget } from '@nextcloud/vue-dashboard'
 
 export default {
     name: 'Dashboard',


### PR DESCRIPTION
Requires a release of https://github.com/nextcloud/nextcloud-vue-dashboard or otherwise npm link-ing the repo